### PR TITLE
Include previous assistant context for short user messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# CLAUDE.md
+
+## Code Review Policy
+
+When addressing CodeRabbit or other automated code review feedback:
+
+- **Nitpicks are NOT optional** - Address all nitpicks, not just actionable comments
+- Example code should follow the same standards as library code
+- Fix all linter warnings, even in example files

--- a/examples/notify-turn-hook.py
+++ b/examples/notify-turn-hook.py
@@ -65,11 +65,12 @@ def _acquire_lock() -> bool:
     try:
         fd = os.open(LOCKFILE, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
         os.close(fd)
-        return True
     except FileExistsError:
         return False
     except OSError:
         return False
+    else:
+        return True
 
 
 def _release_lock() -> None:
@@ -180,11 +181,12 @@ def get_last_user_message(transcript_path: Path) -> str:
                         break  # Only break when we found non-empty text
             if prev_assistant_text:
                 return f"(In response to: {prev_assistant_text}{ellipsis})\nUser said: {last_user_msg}"
-        return last_user_msg
     except (OSError, json.JSONDecodeError, KeyError, ValueError) as e:
         if DEBUG:
             print(f"Debug: get_last_user_message error: {e}", file=sys.stderr)
         return ""
+    else:
+        return last_user_msg
 
 
 def get_assistant_messages(transcript_path: Path) -> str:

--- a/examples/notify-turn-hook.py
+++ b/examples/notify-turn-hook.py
@@ -153,10 +153,10 @@ def get_last_user_message(transcript_path: Path) -> str:
         if not user_entries:
             return ""
 
-        last_user_msg = user_entries[-1]["message"]["content"][:USER_MESSAGE_LIMIT]
+        last_user_msg = user_entries[-1]["message"]["content"].strip()[:USER_MESSAGE_LIMIT]
 
         # If user message is very short, include previous assistant context
-        if len(last_user_msg.strip()) < SHORT_MESSAGE_THRESHOLD:
+        if len(last_user_msg) < SHORT_MESSAGE_THRESHOLD:
             last_user_ts = parse_timestamp(user_entries[-1]["timestamp"])
             # Find assistant message just before the last user message
             prev_assistant_text = ""
@@ -180,9 +180,7 @@ def get_last_user_message(transcript_path: Path) -> str:
                         break  # Only break when we found non-empty text
             if prev_assistant_text:
                 return f"(In response to: {prev_assistant_text}{ellipsis})\nUser said: {last_user_msg}"
-            return last_user_msg
-        else:
-            return last_user_msg
+        return last_user_msg
     except (OSError, json.JSONDecodeError, KeyError, ValueError) as e:
         if DEBUG:
             print(f"Debug: get_last_user_message error: {e}", file=sys.stderr)

--- a/examples/notify-turn-hook.py
+++ b/examples/notify-turn-hook.py
@@ -165,8 +165,9 @@ def get_last_user_message(transcript_path: Path) -> str:
                     break
             if prev_assistant_text:
                 return f"(In response to: {prev_assistant_text}{ellipsis})\nUser said: {last_user_msg}"
-
-        return last_user_msg
+            return last_user_msg
+        else:
+            return last_user_msg
     except (OSError, json.JSONDecodeError, KeyError, ValueError) as e:
         if DEBUG:
             print(f"Debug: get_last_user_message error: {e}", file=sys.stderr)

--- a/examples/notify-turn-hook.py
+++ b/examples/notify-turn-hook.py
@@ -133,21 +133,27 @@ def get_last_user_message(transcript_path: Path) -> str:
             last_user_ts = user_entries[-1]["timestamp"]
             # Find assistant message just before the last user message
             prev_assistant_text = ""
+            ellipsis = ""
             for e in reversed(entries):
                 if e.get("timestamp", "") >= last_user_ts:
                     continue
                 if e.get("type") == "assistant":
                     content = e.get("message", {}).get("content", [])
+                    full_text = ""
                     if isinstance(content, list):
                         for item in content:
                             if isinstance(item, dict) and item.get("type") == "text":
-                                prev_assistant_text = item.get("text", "")[:300]
+                                full_text = item.get("text", "")
                                 break
                     elif isinstance(content, str):
-                        prev_assistant_text = content[:300]
+                        full_text = content
+                    if full_text:
+                        truncated = len(full_text) > 300
+                        prev_assistant_text = full_text[:300]
+                        ellipsis = "..." if truncated else ""
                     break
             if prev_assistant_text:
-                return f"(In response to: {prev_assistant_text}...)\nUser said: {last_user_msg}"
+                return f"(In response to: {prev_assistant_text}{ellipsis})\nUser said: {last_user_msg}"
 
         return last_user_msg
     except Exception as e:

--- a/examples/notify-turn-hook.py
+++ b/examples/notify-turn-hook.py
@@ -130,12 +130,19 @@ def get_last_user_message(transcript_path: Path) -> str:
 
         # If user message is very short, include previous assistant context
         if len(last_user_msg.strip()) < 20:
-            last_user_ts = user_entries[-1]["timestamp"]
+            last_user_ts = parse_timestamp(user_entries[-1]["timestamp"])
             # Find assistant message just before the last user message
             prev_assistant_text = ""
             ellipsis = ""
             for e in reversed(entries):
-                if e.get("timestamp", "") >= last_user_ts:
+                entry_ts_str = e.get("timestamp", "")
+                if not entry_ts_str:
+                    continue
+                try:
+                    entry_ts = parse_timestamp(entry_ts_str)
+                except ValueError:
+                    continue
+                if entry_ts >= last_user_ts:
                     continue
                 if e.get("type") == "assistant":
                     content = e.get("message", {}).get("content", [])

--- a/examples/notify-turn-hook.py
+++ b/examples/notify-turn-hook.py
@@ -153,7 +153,7 @@ def get_last_user_message(transcript_path: Path) -> str:
     except Exception as e:
         if DEBUG:
             print(f"Debug: get_last_user_message error: {e}", file=sys.stderr)
-    return ""
+        return ""
 
 
 def get_assistant_messages(transcript_path: Path) -> str:

--- a/tests/test_notify_hook.py
+++ b/tests/test_notify_hook.py
@@ -240,17 +240,39 @@ class TestHookFunctions(unittest.TestCase):
         hook = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(hook)
 
+        # Use a message longer than 20 chars to avoid context injection
         self._create_transcript([
             {"type": "user", "timestamp": "2025-01-01T10:00:00Z",
-             "message": {"content": "first message"}},
+             "message": {"content": "first message from user"}},
             {"type": "assistant", "timestamp": "2025-01-01T10:01:00Z",
              "message": {"content": [{"type": "text", "text": "response"}]}},
             {"type": "user", "timestamp": "2025-01-01T10:02:00Z",
-             "message": {"content": "second message"}},
+             "message": {"content": "second message from the user"}},
         ])
 
         msg = hook.get_last_user_message(self.transcript)
-        self.assertEqual(msg, "second message")
+        self.assertEqual(msg, "second message from the user")
+
+    def test_get_last_user_message_short_with_context(self):
+        """Test that short user messages include previous assistant context."""
+        import importlib.util
+        hook_path = Path(__file__).parent.parent / "examples" / "notify-turn-hook.py"
+        spec = importlib.util.spec_from_file_location("hook", hook_path)
+        hook = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(hook)
+
+        self._create_transcript([
+            {"type": "user", "timestamp": "2025-01-01T10:00:00Z",
+             "message": {"content": "Do something for me please"}},
+            {"type": "assistant", "timestamp": "2025-01-01T10:01:00Z",
+             "message": {"content": [{"type": "text", "text": "Would you like me to proceed?"}]}},
+            {"type": "user", "timestamp": "2025-01-01T10:02:00Z",
+             "message": {"content": "Yes"}},
+        ])
+
+        msg = hook.get_last_user_message(self.transcript)
+        self.assertIn("Yes", msg)
+        self.assertIn("Would you like me to proceed?", msg)
 
     def test_get_assistant_messages(self):
         """Test extracting assistant messages after last user message."""

--- a/tests/test_notify_hook.py
+++ b/tests/test_notify_hook.py
@@ -271,8 +271,9 @@ class TestHookFunctions(unittest.TestCase):
         ])
 
         msg = hook.get_last_user_message(self.transcript)
-        self.assertIn("Yes", msg)
+        self.assertTrue(msg.startswith("(In response to: "))
         self.assertIn("Would you like me to proceed?", msg)
+        self.assertIn("\nUser said: Yes", msg)
 
     def test_get_assistant_messages(self):
         """Test extracting assistant messages after last user message."""

--- a/tests/test_notify_hook.py
+++ b/tests/test_notify_hook.py
@@ -274,6 +274,26 @@ class TestHookFunctions(unittest.TestCase):
         self.assertTrue(msg.startswith("(In response to: "))
         self.assertIn("Would you like me to proceed?", msg)
         self.assertIn("\nUser said: Yes", msg)
+        # Verify no ellipsis since assistant message is short (not truncated)
+        self.assertNotIn("...", msg)
+
+    def test_get_last_user_message_short_no_prior_assistant(self):
+        """Test that short user message as first message returns just the message."""
+        import importlib.util
+        hook_path = Path(__file__).parent.parent / "examples" / "notify-turn-hook.py"
+        spec = importlib.util.spec_from_file_location("hook", hook_path)
+        hook = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(hook)
+
+        # Short user message with no prior assistant message
+        self._create_transcript([
+            {"type": "user", "timestamp": "2025-01-01T10:00:00Z",
+             "message": {"content": "Yes"}},
+        ])
+
+        msg = hook.get_last_user_message(self.transcript)
+        # Should return just the user message without context
+        self.assertEqual(msg, "Yes")
 
     def test_get_assistant_messages(self):
         """Test extracting assistant messages after last user message."""


### PR DESCRIPTION
## Summary
When the user message is very short (e.g., "Yes", "ok"), the summary model lacks context about what the user was agreeing to. This fix includes the previous assistant message when the user message is under 20 characters, giving the summarizer enough context to produce a meaningful summary.

## Changes
- Modified `get_last_user_message()` in the notify hook to include previous assistant context for short messages
- Added test case for the new behavior

## Test plan
- [x] Existing tests pass
- [x] New test `test_get_last_user_message_short_with_context` verifies the behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Very short user messages now include preceding assistant context for clarity, with prior context truncated as needed.

* **Improvements**
  * More consistent extraction of assistant content, more robust timestamp/transcript parsing, and tighter truncation for summarization inputs.
  * Docstrings and behavior around message-length handling clarified.

* **Tests**
  * Added/updated tests covering short-message context inclusion and fallback scenarios.

* **Documentation**
  * New code review policy document added.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->