### PR TITLE
Add git context prefix to notifications

### DIFF
--- a/tests/test_notify_hook.py
+++ b/tests/test_notify_hook.py
@@ -329,8 +329,12 @@ class TestHookFunctions(unittest.TestCase):
         context = hook.get_git_context(repo_dir)
 
         # Should contain repo name and branch with format "repo, branch: "
-        self.assertIn("audio-notify-server", context)
+        # Verify it's non-empty and has the expected format
+        self.assertNotEqual(context, "")
         self.assertTrue(context.endswith(": "))
+        # Verify it contains a comma if both repo and branch are present,
+        # or just ends with ": " if only repo name
+        self.assertTrue(", " in context or context.count(":") == 1)
 
     def test_get_git_context_empty_cwd(self):
         """Test git context returns empty string for empty cwd."""

--- a/tests/test_notify_hook.py
+++ b/tests/test_notify_hook.py
@@ -315,7 +315,7 @@ class TestHookFunctions(unittest.TestCase):
         self.assertTrue(context.endswith(": "))
         # Verify format matches "repo, branch: " or "repo: "
         self.assertIsNotNone(
-            re.match(r'^.+, .+: $|^.+: $', context),
+            re.match(r'^[^,]+, [^,]+: $|^[^,]+: $', context),
             f"Context '{context}' doesn't match expected format",
         )
 

--- a/tests/test_notify_hook.py
+++ b/tests/test_notify_hook.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -41,7 +42,6 @@ class TestNotifyHook(unittest.TestCase):
 
     def tearDown(self):
         """Clean up after each test."""
-        import shutil
         shutil.rmtree(self.test_dir, ignore_errors=True)
         # Clean up lockfile
         lockfile = Path("/tmp/notify-hook.lock")
@@ -192,7 +192,6 @@ class TestHookFunctions(unittest.TestCase):
 
     def tearDown(self):
         """Clean up."""
-        import shutil
         shutil.rmtree(self.test_dir, ignore_errors=True)
 
     def _create_transcript(self, entries: list):
@@ -304,7 +303,6 @@ class TestHookFunctions(unittest.TestCase):
 
     def test_get_git_context_in_git_repo(self):
         """Test git context returns repo name and branch in a git repo."""
-        import re
         hook = self._import_hook_module()
 
         # Use this test's repo directory

--- a/tests/test_notify_hook.py
+++ b/tests/test_notify_hook.py
@@ -344,17 +344,19 @@ class TestHookFunctions(unittest.TestCase):
         self.assertEqual(context, "")
 
     def test_get_git_context_non_git_dir(self):
-        """Test git context returns empty string for non-git directory."""
+        """Test git context falls back to directory name for non-git directory."""
         import importlib.util
         hook_path = Path(__file__).parent.parent / "examples" / "notify-turn-hook.py"
         spec = importlib.util.spec_from_file_location("hook", hook_path)
         hook = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(hook)
 
-        # Use /tmp which is not a git repo
-        context = hook.get_git_context("/tmp")
-        # Should fall back to directory name without branch
-        self.assertIn("tmp", context)
+        # Use test directory which is not a git repo
+        context = hook.get_git_context(self.test_dir)
+        # Should fall back to directory name
+        dir_name = Path(self.test_dir).name
+        self.assertIn(dir_name, context)
+        self.assertTrue(context.endswith(": "))
 
 
 if __name__ == "__main__":

--- a/tests/test_notify_hook.py
+++ b/tests/test_notify_hook.py
@@ -316,6 +316,46 @@ class TestHookFunctions(unittest.TestCase):
         self.assertIn("working on it", msgs)
         self.assertIn("done!", msgs)
 
+    def test_get_git_context_in_git_repo(self):
+        """Test git context returns repo name and branch in a git repo."""
+        import importlib.util
+        hook_path = Path(__file__).parent.parent / "examples" / "notify-turn-hook.py"
+        spec = importlib.util.spec_from_file_location("hook", hook_path)
+        hook = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(hook)
+
+        # Use this test's repo directory
+        repo_dir = str(Path(__file__).parent.parent)
+        context = hook.get_git_context(repo_dir)
+
+        # Should contain repo name and branch with format "repo, branch: "
+        self.assertIn("audio-notify-server", context)
+        self.assertTrue(context.endswith(": "))
+
+    def test_get_git_context_empty_cwd(self):
+        """Test git context returns empty string for empty cwd."""
+        import importlib.util
+        hook_path = Path(__file__).parent.parent / "examples" / "notify-turn-hook.py"
+        spec = importlib.util.spec_from_file_location("hook", hook_path)
+        hook = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(hook)
+
+        context = hook.get_git_context("")
+        self.assertEqual(context, "")
+
+    def test_get_git_context_non_git_dir(self):
+        """Test git context returns empty string for non-git directory."""
+        import importlib.util
+        hook_path = Path(__file__).parent.parent / "examples" / "notify-turn-hook.py"
+        spec = importlib.util.spec_from_file_location("hook", hook_path)
+        hook = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(hook)
+
+        # Use /tmp which is not a git repo
+        context = hook.get_git_context("/tmp")
+        # Should fall back to directory name without branch
+        self.assertIn("tmp", context)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Add `get_git_context()` function to extract git repo name and branch from the working directory
- Prepend prefix like "repo-name, branch: " to notification messages
- Helps users identify which Claude Code session a notification is from when multiple agents work on different branches

## Test plan
- [x] All 14 hook tests pass
- [x] All 27 total tests pass
- [x] Manual testing with git and non-git directories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications now prepend a Git repository name and branch when available; prefix is computed before building the message and omitted on failure or unavailable Git info.

* **Tests**
  * Added and refactored unit tests covering Git-context extraction (in-repo, non-repo, empty/invalid paths) and introduced a shared helper to streamline test module loading.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->